### PR TITLE
Drop wl-shell in favor of xdg-shell

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -294,23 +294,6 @@ bool LipstickCompositor::completed()
     return m_completed;
 }
 
-int LipstickCompositor::windowIdForLink(QWaylandSurface *s, uint link) const
-{
-    for (QHash<int, LipstickCompositorWindow *>::ConstIterator iter = m_windows.begin();
-        iter != m_windows.end(); ++iter) {
-
-        QWaylandSurface *windowSurface = iter.value()->surface();
-        LipstickCompositorWindow *window = surfaceWindow(windowSurface);
-
-        if (windowSurface && windowSurface->client() && s->client() && window &&
-            windowSurface->client()->processId() == s->client()->processId() &&
-            window->windowProperties().value("WINID", uint(0)).toUInt() == link)
-            return iter.value()->windowId();
-    }
-
-    return 0;
-}
-
 void LipstickCompositor::clearKeyboardFocus()
 {
 //    defaultInputDevice()->setKeyboardFocus(NULL);

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -206,7 +206,6 @@ private:
     void surfaceUnmapped(QWaylandSurface *surface);
     void surfaceUnmapped(LipstickCompositorWindow *item);
 
-    int windowIdForLink(QWaylandSurface *, uint) const;
     void windowAdded(int);
     void windowRemoved(int);
     void windowDestroyed(LipstickCompositorWindow *item);

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -20,7 +20,7 @@
 #include "lipstickglobal.h"
 #include <QWaylandQuickCompositor>
 #include <QWaylandQuickOutput>
-#include <QWaylandWlShellSurface>
+#include <QWaylandXdgShell>
 #include <QWaylandQtWindowManager>
 #include <QQmlComponent>
 #include <QWaylandClient>
@@ -179,8 +179,7 @@ private slots:
     void onHasContentChanged();
     void surfaceSizeChanged();
     void surfaceTitleChanged();
-    void surfaceSetTransient(QWaylandSurface *transientParent, const QPoint &relativeToParent, bool inactive);
-    void surfaceSetFullScreen(QWaylandWlShellSurface::FullScreenMethod method, uint framerate, QWaylandOutput *output);
+    void surfaceSetFullScreen(QWaylandOutput *output);
     void surfaceDamaged(const QRegion &);
     void windowSwapped();
     void windowDestroyed();
@@ -192,7 +191,7 @@ private slots:
     void onSurfaceDying();
     void initialize();
 
-    void onShellSurfaceCreated(QWaylandWlShellSurface *wlShellSurface);
+    void onToplevelCreated(QWaylandXdgToplevel * topLevel, QWaylandXdgSurface * shellSurface);
     void onExtendedSurfaceReady(QtWayland::ExtendedSurface *extSurface, QWaylandSurface *surface);
 
 private:
@@ -246,7 +245,7 @@ private:
     bool m_fakeRepaintTriggered;
     QQuickWindow *m_window;
     QWaylandOutput *m_output;
-    QWaylandWlShell *m_wlShell;
+    QWaylandXdgShell *m_xdgShell;
     QtWayland::SurfaceExtensionGlobal *m_surfExtGlob;
     QWaylandQtWindowManager *m_wm;
 

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -35,7 +35,7 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
 : QWaylandQuickItem(), m_windowId(windowId), m_category(category),
   m_delayRemove(false), m_windowClosed(false), m_removePosted(false),
   m_interceptingTouch(false), m_mapped(false), m_noHardwareComposition(false),
-  m_focusOnTouch(false), m_hasVisibleReferences(false)
+  m_focusOnTouch(false), m_hasVisibleReferences(false), m_extSurface(nullptr)
 {
     setFlags(QQuickItem::ItemIsFocusScope | flags());
 

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -18,7 +18,6 @@
 
 #include <QWaylandQuickItem>
 #include <QWaylandBufferRef>
-#include <QWaylandWlShellSurface>
 #include "lipstickglobal.h"
 
 namespace QtWayland {
@@ -126,7 +125,6 @@ private:
     QList<QMetaObject::Connection> m_surfaceConnections;
     QVector<QQuickItem *> m_refs;
     QtWayland::ExtendedSurface *m_extSurface;
-    QWaylandWlShellSurface *m_wlShellSurface;
 };
 
 #endif // LIPSTICKCOMPOSITORWINDOW_H


### PR DESCRIPTION
`wl-shell` is deprecated. It seems that `xdg-shell` is now the standard.
`xdg-shell` doesn't allow for window extensions, a separate patch is needed to implement support for that (https://github.com/AsteroidOS/meta-asteroid/pull/49).