### PR TITLE
BluetoothAgent: Keep screen awake while pairing popup is visible.

### DIFF
--- a/src/bluetoothagent.h
+++ b/src/bluetoothagent.h
@@ -77,6 +77,7 @@ signals:
     void passkeyChanged();
 
 private:
+    QDBusInterface *m_mceDbus;
     QString mPath;
     HomeWindow *window;
     State state;


### PR DESCRIPTION
Implementation is inspired by https://github.com/AsteroidOS/asteroid-launcher/blob/f7d1f5565e60809f07a9d73d932b26959c0888a4/firstrun.cpp.

For reference sake, I tried Nemo.KeepAlive a while back (https://github.com/MagneFire/lipstick/commit/87f63610f1c556beb712b3f95cb3babe0beb9953) but that did not work, debugging that turns out that Nemo.KeepAlive won't work when the screen is locked. Whenever the watchface is visible the screen is marked as locked.

Only took me more than a year to finally get around to working on this :laughing: 

Finally fixes: https://github.com/AsteroidOS/asteroid-launcher/issues/38