### PR TITLE
Don't show an intermediate black screen during boot.

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -68,7 +68,6 @@ LipstickCompositor::LipstickCompositor()
 {
     m_window = new QQuickWindow();
     m_window->setColor(Qt::black);
-    m_window->setVisible(true);
 
     m_output = new QWaylandQuickOutput(this, m_window);
     m_output->setSizeFollowsWindow(true);
@@ -611,6 +610,7 @@ void LipstickCompositor::reactOnDisplayStateChanges(MeeGo::QmDisplayState::Displ
     }
 
     if (state == MeeGo::QmDisplayState::On) {
+        m_window->setVisible(true);
         emit displayOn();
     } else if (state == MeeGo::QmDisplayState::Off) {
         QCoreApplication::postEvent(this, new QTouchEvent(QEvent::TouchCancel));


### PR DESCRIPTION
Show the window (that contains the loading/loaded qml) once mce deems the screen to be turned on.

This allows for the bootlogo as it was presented to the framebuffer by `psplash` to remain on screen until the main screen is loaded.