### PR TITLE
Compositor: Emit ambient change signals when enabled is changed.

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -706,6 +706,12 @@ void LipstickCompositor::setAmbientEnabled(bool enabled)
         QGuiApplication::platformNativeInterface()->nativeResourceForIntegration("AmbientDisable");
     }
     emit ambientEnabledChanged();
+
+    // Make window visible.
+    reactOnDisplayStateChanges(MeeGo::QmDisplayState::On);
+    // Fire events because enabled changes are not incorporated in above function.
+    emit displayAmbientChanged();
+    emit displayAmbientLeft();
 }
 
 void LipstickCompositor::scheduleAmbientUpdate()


### PR DESCRIPTION
Ambient mode changes should also fire when ambient mode is enabled or disabled.
This fixes the issue where the launcher would remain in ambient mode right after boot as mce reports the display as off and ambient mode is enabled by default (mce will only report later that ambient mode is either enabled or disabled).


This is a demo of the issue actually: https://twitter.com/tontan1998/status/1511361960486764545