### PR TITLE
Stop trying to build non-existing ut_batterynotifier tests

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,13 +1,11 @@
 TEMPLATE = subdirs
 SUBDIRS = \
-          ut_batterynotifier \
           ut_categorydefinitionstore \
           ut_closeeventeater \
           ut_devicelock \
           ut_diskspacenotifier \
           ut_launchermodel \
           ut_lipsticksettings \
-          ut_lowbatterynotifier \
           ut_lipsticknotification \
           ut_notificationfeedbackplayer \
           ut_notificationlistmodel \


### PR DESCRIPTION
They got deleted in https://github.com/AsteroidOS/lipstick/commit/b431c7ee06740d86f242077c0bd225aa36fbfbe0