### PR TITLE
compositor: Send mouse move event to ensure window focus.

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -292,6 +292,12 @@ void LipstickCompositorWindow::wheelEvent(QWheelEvent *event)
     QWaylandSurface *m_surface = surface();
     if (m_surface) {
         QWaylandSeat *inputDevice = m_surface->compositor()->seatFor(event);
+        QWaylandView *v = view();
+        // Hover mouse above window to allow wheel events to arrive.
+        if (v != inputDevice->mouseFocus()) {
+            QPointF pos(0, 0);
+            inputDevice->sendMouseMoveEvent(v, pos, pos);
+        }
         inputDevice->sendMouseWheelEvent(event->orientation(), event->delta());
     } else {
         event->ignore();


### PR DESCRIPTION
`sendMouseWheelEvent()` doesn't ensure that the window gets focused leading to wheel events never arriving in applications until the window is hovered by means of a `sendMouseMoveEvent()` event. This works well for desktop applications but not for mobile applications where one might want to use a rotary input the moment a window is opened. This sends a `sendMouseMoveEvent()` call such that the `ensureEntered()` is called which calls the send_enter() which appears to be needed in order for wheel events to arrive (it informs the Wayland client).


This fixes https://github.com/AsteroidOS/asteroid-launcher/issues/92.