### PR TITLE
Sdk to ssh mode

### DIFF
--- a/i18n/lipstick-ar_AR.ts
+++ b/i18n/lipstick-ar_AR.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>وضع ال SDK يعمل</translation>
+        <source>SSH mode in use</source>
+        <translation>وضع ال SSH يعمل</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-ast.ts
+++ b/i18n/lipstick-ast.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Mou SDK n&apos;usu</translation>
+        <source>SSH mode in use</source>
+        <translation>Mou SSH n&apos;usu</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-az.ts
+++ b/i18n/lipstick-az.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK rejimi istifadə olunur</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH rejimi istifadə olunur</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-cs.ts
+++ b/i18n/lipstick-cs.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Je používán SDK režim</translation>
+        <source>SSH mode in use</source>
+        <translation>Je používán SSH režim</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-da.ts
+++ b/i18n/lipstick-da.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK-tilstand i brug</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH-tilstand i brug</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-de_DE.ts
+++ b/i18n/lipstick-de_DE.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK-Modus in Nutzung</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH-Modus in Nutzung</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-el.ts
+++ b/i18n/lipstick-el.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Σύνδεση σε SDK mode</translation>
+        <source>SSH mode in use</source>
+        <translation>Σύνδεση σε SSH mode</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-en_GB.ts
+++ b/i18n/lipstick-en_GB.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK mode in use</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH mode in use</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-eo.ts
+++ b/i18n/lipstick-eo.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>En SDK-reĝimo</translation>
+        <source>SSH mode in use</source>
+        <translation>En SSH-reĝimo</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-es.ts
+++ b/i18n/lipstick-es.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Modo SDK en uso</translation>
+        <source>SSH mode in use</source>
+        <translation>Modo SSH en uso</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-es_AR.ts
+++ b/i18n/lipstick-es_AR.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Modo SDK en uso</translation>
+        <source>SSH mode in use</source>
+        <translation>Modo SSH en uso</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-fa.ts
+++ b/i18n/lipstick-fa.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>در حال استفاده از SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>در حال استفاده از SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-fi.ts
+++ b/i18n/lipstick-fi.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK tila käytössä</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH tila käytössä</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-fr.ts
+++ b/i18n/lipstick-fr.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Mode SDK activé</translation>
+        <source>SSH mode in use</source>
+        <translation>Mode SSH activé</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-gl.ts
+++ b/i18n/lipstick-gl.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Modo SDK en uso</translation>
+        <source>SSH mode in use</source>
+        <translation>Modo SSH en uso</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-he.ts
+++ b/i18n/lipstick-he.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>נעשה שימוש במצב SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>נעשה שימוש במצב SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-hi.ts
+++ b/i18n/lipstick-hi.ts
@@ -136,7 +136,7 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
+        <source>SSH mode in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="qtn_usb_sync_active">

--- a/i18n/lipstick-hr.ts
+++ b/i18n/lipstick-hr.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Koristi se SDK modus</translation>
+        <source>SSH mode in use</source>
+        <translation>Koristi se SSH modus</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-hu.ts
+++ b/i18n/lipstick-hu.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK mód használatban</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH mód használatban</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-id.ts
+++ b/i18n/lipstick-id.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Mode SDK digunakan</translation>
+        <source>SSH mode in use</source>
+        <translation>Mode SSH digunakan</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-it.ts
+++ b/i18n/lipstick-it.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Modalità SDK in uso</translation>
+        <source>SSH mode in use</source>
+        <translation>Modalità SSH in uso</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-ja.ts
+++ b/i18n/lipstick-ja.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDKモード使用中</translation>
+        <source>SSH mode in use</source>
+        <translation>SSHモード使用中</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-kab.ts
+++ b/i18n/lipstick-kab.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Askar SDK yettwaseqdac</translation>
+        <source>SSH mode in use</source>
+        <translation>Askar SSH yettwaseqdac</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-ko.ts
+++ b/i18n/lipstick-ko.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK 모드 사용 중</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH 모드 사용 중</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-lb.ts
+++ b/i18n/lipstick-lb.ts
@@ -136,7 +136,7 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
+        <source>SSH mode in use</source>
         <translation></translation>
     </message>
     <message id="qtn_usb_sync_active">

--- a/i18n/lipstick-lt.ts
+++ b/i18n/lipstick-lt.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Naudojamas SDK rėžimas</translation>
+        <source>SSH mode in use</source>
+        <translation>Naudojamas SSH rėžimas</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-mr.ts
+++ b/i18n/lipstick-mr.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>वापरात असलेला एसडीके मोड</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH मोड वापरात आहे</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-nb_NO.ts
+++ b/i18n/lipstick-nb_NO.ts
@@ -138,8 +138,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK-modus i bruk</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH-modus i bruk</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-nl.ts
+++ b/i18n/lipstick-nl.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK-modus in gebruik</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH-modus in gebruik</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-nl_BE.ts
+++ b/i18n/lipstick-nl_BE.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK-modus in gebruik</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH-modus in gebruik</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-pl.ts
+++ b/i18n/lipstick-pl.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Tryb SDK w użyciu</translation>
+        <source>SSH mode in use</source>
+        <translation>Tryb SSH w użyciu</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-pt.ts
+++ b/i18n/lipstick-pt.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>A usar o modo SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>A usar o modo SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-pt_BR.ts
+++ b/i18n/lipstick-pt_BR.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Modo SDK em uso</translation>
+        <source>SSH mode in use</source>
+        <translation>Modo SSH em uso</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-pt_PT.ts
+++ b/i18n/lipstick-pt_PT.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>A usar o modo SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>A usar o modo SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-ro.ts
+++ b/i18n/lipstick-ro.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Modul SDK în uz</translation>
+        <source>SSH mode in use</source>
+        <translation>Modul SSH în uz</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-ru.ts
+++ b/i18n/lipstick-ru.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK режим активирован</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH режим активирован</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-rue.ts
+++ b/i18n/lipstick-rue.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK режим хоснує ся</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH режим хоснує ся</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-sk.ts
+++ b/i18n/lipstick-sk.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Používanie režimu SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>Používanie režimu SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-sv.ts
+++ b/i18n/lipstick-sv.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK-läge används</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH-läge används</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-th.ts
+++ b/i18n/lipstick-th.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>ใช้โหมด SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>ใช้โหมด SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-tr.ts
+++ b/i18n/lipstick-tr.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK kipi kullanımda</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH kipi kullanımda</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-uk.ts
+++ b/i18n/lipstick-uk.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Режим SDK використовується</translation>
+        <source>SSH mode in use</source>
+        <translation>Режим SSH використовується</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-vi.ts
+++ b/i18n/lipstick-vi.ts
@@ -136,8 +136,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>Đang sử dụng chế độ SDK</translation>
+        <source>SSH mode in use</source>
+        <translation>Đang sử dụng chế độ SSH</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-zh_Hans.ts
+++ b/i18n/lipstick-zh_Hans.ts
@@ -144,8 +144,8 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
-        <translation>SDK模式正在使用中</translation>
+        <source>SSH mode in use</source>
+        <translation>SSH模式正在使用中</translation>
     </message>
     <message id="qtn_usb_sync_active">
         <location filename="../src/usbmodeselector.cpp" line="144"/>

--- a/i18n/lipstick-zh_Hant.ts
+++ b/i18n/lipstick-zh_Hant.ts
@@ -136,7 +136,7 @@
     <message id="qtn_usb_sdk_active">
         <location filename="../src/usbmodeselector.cpp" line="141"/>
         <location filename="../tests/ut_usbmodeselector/ut_usbmodeselector.cpp" line="184"/>
-        <source>SDK mode in use</source>
+        <source>SSH mode in use</source>
         <translation>開發模式運作中</translation>
     </message>
     <message id="qtn_usb_sync_active">

--- a/src/usbmodeselector.cpp
+++ b/src/usbmodeselector.cpp
@@ -137,7 +137,7 @@ void USBModeSelector::showNotification(QString mode)
             //% "Mass storage in use"
             body = qtTrId("qtn_usb_storage_active");
         } else if (mode == QUsbModed::Mode::Developer) {
-            //% "SDK mode in use"
+            //% "SSH mode in use"
             body = qtTrId("qtn_usb_sdk_active");
         } else if (mode == QUsbModed::Mode::PCSuite) {
             //% "Sync-and-connect in use"


### PR DESCRIPTION
As noted by DocGalaxyBlock in Matrix chat, the "About" screen changed from "SDK mode" to "SSH mode" but other places did not include this change. This changes "SDK mode" to "SSH mode" in all languages so the popup shows the correct message.