### PR TITLE
Fixup closing client

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -275,8 +275,9 @@ QObject *LipstickCompositor::windowForId(int id) const
 void LipstickCompositor::closeClientForWindowId(int id)
 {
     LipstickCompositorWindow *window = m_windows.value(id, 0);
-    if (window && window->surface())
-        destroyClientForSurface(window->surface());
+    if (window && window->surface()) {
+        window->surface()->client()->close();
+    }
 }
 
 QWaylandSurface *LipstickCompositor::surfaceForId(int id) const


### PR DESCRIPTION
this applies neochapay's https://github.com/nemomobile-ux/lipstick/commit/91efdabcb32a1900bf18daaf6518c1a507273f44  .  This makes use of the close method to ensure that apps get closed instead of being crashed, fixing https://github.com/AsteroidOS/asteroid-launcher/issues/163 . Many thanks to neochapay for fixing this so quickly!