### PR TITLE
Send close request to window instead of closing window directly

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -275,9 +275,14 @@ QObject *LipstickCompositor::windowForId(int id) const
 void LipstickCompositor::closeClientForWindowId(int id)
 {
     LipstickCompositorWindow *window = m_windows.value(id, 0);
+
     if (window && window->surface()) {
-        window->surface()->client()->close();
-    }
+        QWaylandQtWindowManager *wmExtension = QWaylandQtWindowManager::findIn(this);
+        if (wmExtension)
+            wmExtension->sendQuitMessage(window->surface()->client());
+        else
+            window->surface()->client()->close();
+    }   
 }
 
 QWaylandSurface *LipstickCompositor::surfaceForId(int id) const


### PR DESCRIPTION
this finally seems to be a correct fix for https://github.com/AsteroidOS/asteroid-launcher/issues/163 ; on the surface this seems to do things 'correctly' and has expected results (consistent exit code 0 from applications). 
previous attempts:
- https://github.com/AsteroidOS/lipstick/pull/20 - this did not actually fix the problem, as both functions end up calling the same code below the surface
- https://github.com/AsteroidOS/meta-asteroid/pull/180 - this made a few naive assumptions about how qtwayland is meant to work . the resulting code would have caused memory leaks, and would have patched qtwayland in a way that is difficult to maintain.
From what I understand, this code should not leak memory in the same way as https://github.com/AsteroidOS/meta-asteroid/pull/180, but once again I will need help as I've not managed to identify everything that is done as the application closes.


Another nuance worth noting is that we get a bit of flickering onscreen as the application is closed - this probably needs some tweaks in asteroid-launcher, but I'd like a review on this before I spend that time. 