### PR TITLE
Migrate to MDConfItem

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -87,7 +87,7 @@ LipstickCompositor::LipstickCompositor()
     if (m_instance) qFatal("LipstickCompositor: Only one compositor instance per process is supported");
     m_instance = this;
 
-    m_orientationLock = new MGConfItem("/lipstick/orientationLock", this);
+    m_orientationLock = new MDConfItem("/lipstick/orientationLock", this);
     connect(m_orientationLock, SIGNAL(valueChanged()), SIGNAL(orientationLockChanged()));
 
     // Load legacy settings from the config file and delete it from there

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -26,7 +26,7 @@
 #include <QWaylandClient>
 #include <QPointer>
 #include <QTimer>
-#include <MGConfItem>
+#include <MDConfItem>
 #include <qmdisplaystate.h>
 
 #include <timed-qt5/interface>
@@ -111,7 +111,7 @@ public:
     Q_INVOKABLE void clearKeyboardFocus();
     Q_INVOKABLE void setDisplayOff();
     Q_INVOKABLE QVariant settingsValue(const QString &key, const QVariant &defaultValue = QVariant()) const
-        { return (key == "orientationLock") ? m_orientationLock->value(defaultValue) : MGConfItem("/lipstick/" + key).value(defaultValue); }
+        { return (key == "orientationLock") ? m_orientationLock->value(defaultValue) : MDConfItem("/lipstick/" + key).value(defaultValue); }
 
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &);
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &, QQuickItem *rootItem);
@@ -236,7 +236,7 @@ private:
     MeeGo::QmDisplayState *m_displayState;
     QOrientationSensor* m_orientationSensor;
     QPointer<QMimeData> m_retainedSelection;
-    MGConfItem *m_orientationLock;
+    MDConfItem *m_orientationLock;
     MeeGo::QmDisplayState::DisplayState m_currentDisplayState;
     bool m_updatesEnabled;
     bool m_completed;

--- a/src/devicelock/devicelock.h
+++ b/src/devicelock/devicelock.h
@@ -22,7 +22,7 @@
 #include <QDBusPendingCallWatcher>
 #include <keepalive/backgroundactivity.h>
 
-class MGConfItem;
+class MDConfItem;
 class QTimer;
 
 class DeviceLock : public QObject, protected QDBusContext

--- a/src/lipsticksettings.cpp
+++ b/src/lipsticksettings.cpp
@@ -17,7 +17,7 @@
 
 #include <QGuiApplication>
 #include <QScreen>
-#include <MGConfItem>
+#include <MDConfItem>
 #include "screenlock/screenlock.h"
 #include "homeapplication.h"
 #include "lipsticksettings.h"
@@ -81,12 +81,12 @@ QSize LipstickSettings::screenSize()
 void LipstickSettings::exportScreenSize()
 {
     const int defaultValue = 0;
-    MGConfItem widthConf("/lipstick/screen/primary/width");
+    MDConfItem widthConf("/lipstick/screen/primary/width");
     if (widthConf.value(defaultValue) != QGuiApplication::primaryScreen()->size().width()) {
         widthConf.set(QGuiApplication::primaryScreen()->size().width());
         widthConf.sync();
     }
-    MGConfItem heightConf("/lipstick/screen/primary/height");
+    MDConfItem heightConf("/lipstick/screen/primary/height");
     if (heightConf.value(defaultValue) != QGuiApplication::primaryScreen()->size().height()) {
         heightConf.set(QGuiApplication::primaryScreen()->size().height());
         heightConf.sync();

--- a/src/volume/volumecontrol.cpp
+++ b/src/volume/volumecontrol.cpp
@@ -21,7 +21,7 @@
 #include <QQmlContext>
 #include <QScreen>
 #include <QKeyEvent>
-#include <MGConfItem>
+#include <MDConfItem>
 #include "utilities/closeeventeater.h"
 #include "pulseaudiocontrol.h"
 #include "volumecontrol.h"
@@ -35,7 +35,7 @@ VolumeControl::VolumeControl(QObject *parent) :
     hwKeysAcquired(false),
     volume_(0),
     maximumVolume_(0),
-    audioWarning(new MGConfItem("/desktop/nemo/audiowarning", this)),
+    audioWarning(new MDConfItem("/desktop/nemo/audiowarning", this)),
     safeVolume_(0),
     callActive_(false),
     mediaState_(MediaStateUnknown)

--- a/src/volume/volumecontrol.h
+++ b/src/volume/volumecontrol.h
@@ -23,7 +23,7 @@
 class HomeWindow;
 class PulseAudioControl;
 class VolumeKeyListener;
-class MGConfItem;
+class MDConfItem;
 
 namespace ResourcePolicy {
     class ResourceSet;
@@ -218,7 +218,7 @@ private:
     int maximumVolume_;
 
     //! Stores audio warning acknowledgement state
-    MGConfItem *audioWarning;
+    MDConfItem *audioWarning;
 
     //! The current safe volume
     int safeVolume_;

--- a/tests/stubs/mgconfitem_stub.h
+++ b/tests/stubs/mgconfitem_stub.h
@@ -1,16 +1,16 @@
 #ifndef MGCONFITEM_STUB
 #define MGCONFITEM_STUB
 
-#include "mgconfitem.h"
+#include "mdconfitem.h"
 #include <stubbase.h>
 
 
 // 1. DECLARE STUB
 // FIXME - stubgen is not yet finished
-class MGConfItemStub : public StubBase {
+class MDConfItemStub : public StubBase {
   public:
-  virtual void MGConfItemConstructor(const QString &key, QObject *parent);
-  virtual void MGConfItemDestructor();
+  virtual void MDConfItemConstructor(const QString &key, QObject *parent);
+  virtual void MDConfItemDestructor();
   virtual QString key() const;
   virtual QVariant value() const;
   virtual QVariant value(const QVariant &def) const;
@@ -19,75 +19,75 @@ class MGConfItemStub : public StubBase {
 }; 
 
 // 2. IMPLEMENT STUB
-void MGConfItemStub::MGConfItemConstructor(const QString &key, QObject *parent) {
+void MDConfItemStub::MDConfItemConstructor(const QString &key, QObject *parent) {
   Q_UNUSED(key);
   Q_UNUSED(parent);
 
 }
-void MGConfItemStub::MGConfItemDestructor() {
+void MDConfItemStub::MDConfItemDestructor() {
 
 }
-QString MGConfItemStub::key() const {
+QString MDConfItemStub::key() const {
   stubMethodEntered("key");
   return stubReturnValue<QString>("key");
 }
 
-QVariant MGConfItemStub::value() const {
+QVariant MDConfItemStub::value() const {
   stubMethodEntered("value");
   return stubReturnValue<QVariant>("value");
 }
 
-QVariant MGConfItemStub::value(const QVariant &def) const {
+QVariant MDConfItemStub::value(const QVariant &def) const {
   QList<ParameterBase*> params;
   params.append( new Parameter<const QVariant & >(def));
   stubMethodEntered("value",params);
   return stubReturnValue<QVariant>("value");
 }
 
-void MGConfItemStub::set(const QVariant &val) {
+void MDConfItemStub::set(const QVariant &val) {
   QList<ParameterBase*> params;
   params.append( new Parameter<const QVariant & >(val));
   stubMethodEntered("set",params);
 }
 
-void MGConfItemStub::unset() {
+void MDConfItemStub::unset() {
   stubMethodEntered("unset");
 }
 
 
 
 // 3. CREATE A STUB INSTANCE
-MGConfItemStub gDefaultMGConfItemStub;
-MGConfItemStub* gMGConfItemStub = &gDefaultMGConfItemStub;
+MDConfItemStub gDefaultMDConfItemStub;
+MDConfItemStub* gMDConfItemStub = &gDefaultMDConfItemStub;
 
 
 // 4. CREATE A PROXY WHICH CALLS THE STUB
-MGConfItem::MGConfItem(const QString &key, QObject *parent) {
-  gMGConfItemStub->MGConfItemConstructor(key, parent);
+MDConfItem::MDConfItem(const QString &key, QObject *parent) {
+  gMDConfItemStub->MDConfItemConstructor(key, parent);
 }
 
-MGConfItem::~MGConfItem() {
-  gMGConfItemStub->MGConfItemDestructor();
+MDConfItem::~MDConfItem() {
+  gMDConfItemStub->MDConfItemDestructor();
 }
 
-QString MGConfItem::key() const {
-  return gMGConfItemStub->key();
+QString MDConfItem::key() const {
+  return gMDConfItemStub->key();
 }
 
-QVariant MGConfItem::value() const {
-  return gMGConfItemStub->value();
+QVariant MDConfItem::value() const {
+  return gMDConfItemStub->value();
 }
 
-QVariant MGConfItem::value(const QVariant &def) const {
-  return gMGConfItemStub->value(def);
+QVariant MDConfItem::value(const QVariant &def) const {
+  return gMDConfItemStub->value(def);
 }
 
-void MGConfItem::set(const QVariant &val) {
-  gMGConfItemStub->set(val);
+void MDConfItem::set(const QVariant &val) {
+  gMDConfItemStub->set(val);
 }
 
-void MGConfItem::unset() {
-  gMGConfItemStub->unset();
+void MDConfItem::unset() {
+  gMDConfItemStub->unset();
 }
 
 

--- a/tests/ut_volumecontrol/ut_volumecontrol.cpp
+++ b/tests/ut_volumecontrol/ut_volumecontrol.cpp
@@ -20,7 +20,7 @@
 #include "volumecontrol.h"
 #include "pulseaudiocontrol_stub.h"
 #include "closeeventeater_stub.h"
-#include "mgconfitem_stub.h"
+#include "mdconfitem_stub.h"
 #include "lipstickqmlpath_stub.h"
 
 extern "C"

--- a/tests/ut_volumecontrol/ut_volumecontrol.pro
+++ b/tests/ut_volumecontrol/ut_volumecontrol.pro
@@ -12,7 +12,7 @@ HEADERS += \
     $$VOLUMESRCDIR/pulseaudiocontrol.h \
     $$UTILITYSRCDIR/closeeventeater.h \
     $$SRCDIR/homewindow.h \
-    /usr/include/mlite5/mgconfitem.h \
+    /usr/include/mlite5/mdconfitem.h \
 
 SOURCES += \
     ut_volumecontrol.cpp \


### PR DESCRIPTION
With mlite 0.5.0 MGConfItem is deprecated in favor of GDConfItem, which has the identical API but renamed.

Ref: https://github.com/sailfishos/mlite/commit/055c4aa2ba7a5b3d76cfd00365a67e07c937c047