### PR TITLE
Add Wayland gesture-override extension

### DIFF
--- a/src/compositor/asteroidgesturesextension.cpp
+++ b/src/compositor/asteroidgesturesextension.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Florent Revest <revestflo@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ */
+
+#include "asteroidgesturesextension.h"
+
+#include <QWaylandCompositor>
+#include <QWaylandSurface>
+#include <QWaylandView>
+
+#include "lipstickcompositorwindow.h"
+
+AsteroidGesturesManager::AsteroidGesturesManager(QWaylandCompositor *compositor)
+    : QWaylandCompositorExtensionTemplate<AsteroidGesturesManager>(compositor)
+{
+}
+
+void AsteroidGesturesManager::initialize()
+{
+    QWaylandCompositorExtensionTemplate::initialize();
+    auto *compositor = static_cast<QWaylandCompositor *>(extensionContainer());
+    init(compositor->display(), 1);
+}
+
+void AsteroidGesturesManager::zasteroid_gestures_manager_v1_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void AsteroidGesturesManager::zasteroid_gestures_manager_v1_get_gesture_surface(
+    Resource *resource, uint32_t id, ::wl_resource *surface_resource)
+{
+    auto *surface = QWaylandSurface::fromResource(surface_resource);
+    new AsteroidGestureSurface(resource->client(), id, resource->version(), surface);
+}
+
+AsteroidGestureSurface::AsteroidGestureSurface(wl_client *client, uint32_t id, int version,
+                                               QWaylandSurface *surface)
+    : QtWaylandServer::zasteroid_gesture_surface_v1(client, id, version)
+    , m_surface(surface)
+{
+}
+
+AsteroidGestureSurface::~AsteroidGestureSurface() = default;
+
+void AsteroidGestureSurface::zasteroid_gesture_surface_v1_destroy_resource(Resource *)
+{
+    applyToWindow(false);
+    delete this;
+}
+
+void AsteroidGestureSurface::zasteroid_gesture_surface_v1_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void AsteroidGestureSurface::zasteroid_gesture_surface_v1_set_overrides_system_gestures(
+    Resource *, uint32_t enabled)
+{
+    applyToWindow(enabled != 0);
+}
+
+void AsteroidGestureSurface::applyToWindow(bool enabled)
+{
+    if (!m_surface)
+        return;
+    const auto views = m_surface->views();
+    for (QWaylandView *view : views) {
+        if (auto *window = qobject_cast<LipstickCompositorWindow *>(view->renderObject())) {
+            window->setOverridesSystemGestures(enabled);
+            return;
+        }
+    }
+}

--- a/src/compositor/asteroidgesturesextension.h
+++ b/src/compositor/asteroidgesturesextension.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Florent Revest <revestflo@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ */
+
+#ifndef ASTEROIDGESTURESEXTENSION_H
+#define ASTEROIDGESTURESEXTENSION_H
+
+#include <QWaylandCompositorExtensionTemplate>
+#include "qwayland-server-asteroid-gestures-unstable-v1.h"
+
+class QWaylandSurface;
+class LipstickCompositorWindow;
+
+class AsteroidGesturesManager
+    : public QWaylandCompositorExtensionTemplate<AsteroidGesturesManager>,
+      public QtWaylandServer::zasteroid_gestures_manager_v1
+{
+    Q_OBJECT
+public:
+    explicit AsteroidGesturesManager(QWaylandCompositor *compositor);
+
+    void initialize() override;
+
+protected:
+    void zasteroid_gestures_manager_v1_destroy(Resource *resource) override;
+    void zasteroid_gestures_manager_v1_get_gesture_surface(
+        Resource *resource, uint32_t id, ::wl_resource *surface_resource) override;
+};
+
+class AsteroidGestureSurface : public QtWaylandServer::zasteroid_gesture_surface_v1
+{
+public:
+    AsteroidGestureSurface(wl_client *client, uint32_t id, int version,
+                           QWaylandSurface *surface);
+    ~AsteroidGestureSurface() override;
+
+protected:
+    void zasteroid_gesture_surface_v1_destroy_resource(Resource *resource) override;
+    void zasteroid_gesture_surface_v1_destroy(Resource *resource) override;
+    void zasteroid_gesture_surface_v1_set_overrides_system_gestures(
+        Resource *resource, uint32_t enabled) override;
+
+private:
+    void applyToWindow(bool enabled);
+
+    QPointer<QWaylandSurface> m_surface;
+};
+
+#endif // ASTEROIDGESTURESEXTENSION_H

--- a/src/compositor/compositor.pri
+++ b/src/compositor/compositor.pri
@@ -11,7 +11,8 @@ PUBLICHEADERS += \
 
 HEADERS += \
     $$PWD/windowpixmapitem.h \
-    $$PWD/lipstickrecorder.h
+    $$PWD/lipstickrecorder.h \
+    $$PWD/asteroidgesturesextension.h
 
 SOURCES += \
     $$PWD/lipstickcompositor.cpp \
@@ -19,7 +20,11 @@ SOURCES += \
     $$PWD/lipstickcompositorprocwindow.cpp \
     $$PWD/lipstickcompositoradaptor.cpp \
     $$PWD/windowmodel.cpp \
-    $$PWD/windowpixmapitem.cpp
+    $$PWD/windowpixmapitem.cpp \
+    $$PWD/asteroidgesturesextension.cpp
+
+CONFIG += wayland-scanner
+WAYLANDSERVERSOURCES += $$PWD/../../wayland-protocols/asteroid-gestures-unstable-v1.xml
 
 DEFINES += QT_COMPOSITOR_QUICK
 

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -30,6 +30,7 @@
 #include "lipstickcompositor.h"
 #include "lipstickcompositoradaptor.h"
 #include "lipsticksettings.h"
+#include "asteroidgesturesextension.h"
 #include <qpa/qwindowsysteminterface.h>
 #include <private/qguiapplication_p.h>
 #include <QtGui/qpa/qplatformintegration.h>
@@ -76,6 +77,8 @@ LipstickCompositor::LipstickCompositor()
 
     m_wm = new QWaylandQtWindowManager(this);
     connect(m_wm, &QWaylandQtWindowManager::openUrl, this, &LipstickCompositor::openUrl);
+
+    m_gesturesManager = new AsteroidGesturesManager(this);
 
     setRetainedSelectionEnabled(true);
 

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -39,6 +39,7 @@ class LipstickCompositorWindow;
 class LipstickCompositorProcWindow;
 class QOrientationSensor;
 class LipstickRecorderManager;
+class AsteroidGesturesManager;
 
 class LIPSTICK_EXPORT LipstickCompositor : public QWaylandQuickCompositor
 {
@@ -241,6 +242,7 @@ private:
     QWaylandOutput *m_output;
     QWaylandXdgShell *m_xdgShell;
     QWaylandQtWindowManager *m_wm;
+    AsteroidGesturesManager *m_gesturesManager;
 
     Maemo::Timed::Interface *m_timedDbus;
     bool m_ambientModeEnabled;

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -29,7 +29,7 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
 : QWaylandQuickItem(), m_windowId(windowId), m_category(category),
   m_delayRemove(false), m_windowClosed(false), m_removePosted(false),
   m_interceptingTouch(false), m_mapped(false), m_processId(0),
-  m_focusOnTouch(false)
+  m_focusOnTouch(false), m_overridesSystemGestures(false)
 {
     setFlags(QQuickItem::ItemIsFocusScope | flags());
 
@@ -373,5 +373,19 @@ void LipstickCompositorWindow::setFocusOnTouch(bool focusOnTouch)
 
     m_focusOnTouch = focusOnTouch;
     emit focusOnTouchChanged();
+}
+
+bool LipstickCompositorWindow::overridesSystemGestures() const
+{
+    return m_overridesSystemGestures;
+}
+
+void LipstickCompositorWindow::setOverridesSystemGestures(bool enabled)
+{
+    if (m_overridesSystemGestures == enabled)
+        return;
+
+    m_overridesSystemGestures = enabled;
+    emit overridesSystemGesturesChanged();
 }
 

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -34,6 +34,7 @@ class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandQuickItem
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(qint64 processId READ processId CONSTANT)
     Q_PROPERTY(qint16 windowFlags READ windowFlags NOTIFY windowFlagsChanged)
+    Q_PROPERTY(bool overridesSystemGestures READ overridesSystemGestures NOTIFY overridesSystemGesturesChanged)
 
     Q_PROPERTY(bool focusOnTouch READ focusOnTouch WRITE setFocusOnTouch NOTIFY focusOnTouchChanged)
 
@@ -62,6 +63,9 @@ public:
     bool focusOnTouch() const;
     void setFocusOnTouch(bool focusOnTouch);
 
+    bool overridesSystemGestures() const;
+    void setOverridesSystemGestures(bool enabled);
+
     QVariantMap windowProperties();
 
 protected:
@@ -81,6 +85,7 @@ signals:
     void committed();
     void focusOnTouchChanged();
     void windowFlagsChanged();
+    void overridesSystemGesturesChanged();
 
 private slots:
     void handleTouchCancel();
@@ -110,6 +115,7 @@ private:
     bool m_mapped : 1;
     bool m_noHardwareComposition: 1;
     bool m_focusOnTouch : 1;
+    bool m_overridesSystemGestures : 1;
     QVariant m_data;
     QVector<QQuickItem *> m_refs;
 };

--- a/wayland-protocols/asteroid-gestures-unstable-v1.xml
+++ b/wayland-protocols/asteroid-gestures-unstable-v1.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="asteroid_gestures_unstable_v1">
+  <copyright>
+    Copyright (C) 2026 Florent Revest &lt;revestflo@gmail.com&gt;
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice (including the
+    next paragraph) shall be included in all copies or substantial portions
+    of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="lets clients hint gesture policy to the compositor">
+    AsteroidOS-specific protocol used by clients to tell the compositor
+    that they want to handle certain navigation gestures themselves
+    instead of having the compositor consume them.
+
+    The compositor is free to honor or ignore these hints.
+  </description>
+
+  <interface name="zasteroid_gestures_manager_v1" version="1">
+    <description summary="gesture policy manager">
+      The global entry point. A client binds it and uses it to obtain
+      per-surface gesture objects.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroys the manager. Previously obtained gesture surfaces are
+        unaffected and must be destroyed separately.
+      </description>
+    </request>
+
+    <request name="get_gesture_surface">
+      <description summary="get a gesture object for a wl_surface"/>
+      <arg name="id" type="new_id" interface="zasteroid_gesture_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+  </interface>
+
+  <interface name="zasteroid_gesture_surface_v1" version="1">
+    <description summary="per-surface gesture policy">
+      Created by zasteroid_gestures_manager_v1.get_gesture_surface. The
+      lifetime of this object is independent of the underlying wl_surface;
+      destroying it returns the surface to default gesture handling.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the per-surface object">
+        Returns the surface to default gesture handling.
+      </description>
+    </request>
+
+    <request name="set_overrides_system_gestures">
+      <description summary="hint that the client handles its own gestures">
+        When enabled is non-zero, the compositor should let edge-swipe and
+        similar navigation gestures reach the client surface instead of
+        consuming them itself (e.g. to close the app or open a system menu).
+
+        The hint takes effect on the next surface commit. The default state
+        for a newly created gesture surface is "disabled".
+      </description>
+      <arg name="enabled" type="uint"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
Replaces the legacy QtWayland extended-surface windowFlags mechanism with a small AsteroidOS-specific Wayland protocol. Clients use zasteroid_gestures_manager_v1.get_gesture_surface to obtain a per-surface object on which they can call set_overrides_system_gestures, telling the compositor to forward edge-swipe navigation gestures to the client instead of consuming them. The compositor advertises the new global, and the resulting state is exposed on LipstickCompositorWindow as the overridesSystemGestures property so QML can react to it.

Full set of PRs for the back gesture fix:
https://github.com/AsteroidOS/qml-asteroid/pull/100
https://github.com/AsteroidOS/lipstick/pull/23
https://github.com/AsteroidOS/asteroid-launcher/pull/234