### PR TITLE
compositor: Turn off display in non-ambient mode when display state goes to Off

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -616,11 +616,18 @@ void LipstickCompositor::reactOnDisplayStateChanges(MeeGo::QmDisplayState::Displ
     }
 
     if (state == MeeGo::QmDisplayState::On) {
-        m_window->setVisible(true);
+        if (!m_updatesEnabled && !ambientEnabled()) {
+            setUpdatesEnabled(true);
+        } else {
+            m_window->setVisible(true);
+        }
         emit displayOn();
     } else if (state == MeeGo::QmDisplayState::Off) {
         QCoreApplication::postEvent(this, new QTouchEvent(QEvent::TouchCancel));
         emit displayOff();
+        if (!ambientEnabled()) {
+            setUpdatesEnabled(false);
+        }
     }
 
     bool changeInDimming = (state == MeeGo::QmDisplayState::Dimmed) != (m_currentDisplayState == MeeGo::QmDisplayState::Dimmed);


### PR DESCRIPTION
When ambient/AOD is disabled and the display goes Off (e.g. power button press), immediately call `setUpdatesEnabled(false)` to hide the compositor window and call the platform `DisplayOff` resource.

Previously the window stayed visible indefinitely because the ambient-only path never triggered — `delayTimer` fired after 5 seconds but `setAmbientUpdatesEnabled(true)` returned immediately when `!ambientEnabled()`.

On wake-up, properly restore via `setUpdatesEnabled(true)` to ensure `DisplayOn` and `displayAboutToBeOn` are emitted.

Refs AsteroidOS/asteroid-launcher#198