### PR TITLE
volume: drop libresource ResourcePolicy arbitration

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -141,7 +141,7 @@ SOURCES += \
 
 CONFIG += link_pkgconfig mobility qt warn_on depend_includepath qmake_cache target_qt
 CONFIG -= link_prl
-PKGCONFIG += mlite6 mce mce-qt6 keepalive dbus-1 dbus-glib-1 libresourceqt6 ngf-qt6 libsystemd dsme_dbus_if thermalmanager_dbus_if usb-moded-qt6 egl
+PKGCONFIG += mlite6 mce mce-qt6 keepalive dbus-1 dbus-glib-1 ngf-qt6 libsystemd dsme_dbus_if thermalmanager_dbus_if usb-moded-qt6 egl
 
 LIBS += -lrt
 

--- a/src/volume/volumecontrol.cpp
+++ b/src/volume/volumecontrol.cpp
@@ -14,7 +14,6 @@
 ****************************************************************************/
 
 #include <dbus/dbus.h>
-#include <policy/resource-set.h>
 #include <linux/input.h>
 #include <QGuiApplication>
 #include "homewindow.h"
@@ -31,8 +30,6 @@ VolumeControl::VolumeControl(QObject *parent) :
     QObject(parent),
     window(0),
     pulseAudioControl(new PulseAudioControl(this)),
-    hwKeyResource(new ResourcePolicy::ResourceSet("event")),
-    hwKeysAcquired(false),
     volume_(0),
     maximumVolume_(0),
     audioWarning(new MDConfItem("/desktop/nemo/audiowarning", this)),
@@ -40,12 +37,6 @@ VolumeControl::VolumeControl(QObject *parent) :
     callActive_(false),
     mediaState_(MediaStateUnknown)
 {
-    hwKeyResource->setAlwaysReply();
-    hwKeyResource->addResourceObject(new ResourcePolicy::ScaleButtonResource);
-    connect(hwKeyResource, SIGNAL(resourcesGranted(QList<ResourcePolicy::ResourceType>)), this, SLOT(hwKeyResourceAcquired()));
-    connect(hwKeyResource, SIGNAL(lostResources()), this, SLOT(hwKeyResourceLost()));
-    hwKeyResource->acquire();
-
     setWarningAcknowledged(false);
     connect(audioWarning, SIGNAL(valueChanged()), this, SIGNAL(restrictedVolumeChanged()));
     connect(this, SIGNAL(maximumVolumeChanged()), this, SIGNAL(restrictedVolumeChanged()));
@@ -62,7 +53,6 @@ VolumeControl::VolumeControl(QObject *parent) :
 
 VolumeControl::~VolumeControl()
 {
-    hwKeyResource->deleteResource(ResourcePolicy::ScaleButtonType);
     delete window;
 }
 
@@ -171,24 +161,6 @@ void VolumeControl::setVolume(int volume, int maximumVolume)
     }
 }
 
-void VolumeControl::hwKeyResourceAcquired()
-{
-    hwKeysAcquired = true;
-}
-
-void VolumeControl::hwKeyResourceLost()
-{
-    hwKeysAcquired = false;
-    if (upPressed_) {
-        upPressed_ = false;
-        emit volumeKeyReleased(Qt::Key_VolumeUp);
-    }
-    if (downPressed_) {
-        downPressed_ = false;
-        emit volumeKeyReleased(Qt::Key_VolumeDown);
-    }
-}
-
 void VolumeControl::handleHighVolume(int safeLevel)
 {
     if (safeVolume_ != safeLevel) {
@@ -261,7 +233,7 @@ void VolumeControl::createWindow()
 
 bool VolumeControl::eventFilter(QObject *, QEvent *event)
 {
-    if (hwKeysAcquired && (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)) {
+    if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         if ((keyEvent->key() == Qt::Key_VolumeUp || keyEvent->key() == Qt::Key_VolumeDown) && !keyEvent->isAutoRepeat()) {
             if (event->type() == QEvent::KeyPress) {

--- a/src/volume/volumecontrol.h
+++ b/src/volume/volumecontrol.h
@@ -25,10 +25,6 @@ class PulseAudioControl;
 class VolumeKeyListener;
 class MDConfItem;
 
-namespace ResourcePolicy {
-    class ResourceSet;
-}
-
 /*!
  * \class VolumeControl
  *
@@ -176,12 +172,6 @@ private slots:
     //! Sets the volume and maximum volume
     void setVolume(int volume, int maximumVolume);
 
-    //! An internal slot to handle the case when we got the hardware volume keys resource
-    void hwKeyResourceAcquired();
-
-    //! An internal slot to handle the case when we lost the hardware volume keys resource
-    void hwKeyResourceLost();
-
     //! Used to capture safe volume level and reset it to safe when needed.
     void handleHighVolume(int safeLevel);
 
@@ -204,12 +194,6 @@ private:
 
     //! PulseAudio volume controller
     PulseAudioControl *pulseAudioControl;
-
-    //! A resource object for access to the volume keys
-    ResourcePolicy::ResourceSet *hwKeyResource;
-
-    //! Whether to react to volume key presses
-    bool hwKeysAcquired;
 
     //! The current volume
     int volume_;


### PR DESCRIPTION
The hardware volume keys were guarded behind a Mer ResourceSet ("scale button" resource). AsteroidOS ships no resourced daemon to grant it, and watches drive volume from the QuickPanel slider, so the arbitration only added a dependency on libresourceqt. Handle the keys directly instead.

Removes lipstick's last use of libresourceqt6.